### PR TITLE
Added support for Azure Service Bus Queue Integration

### DIFF
--- a/alert/rule/const.go
+++ b/alert/rule/const.go
@@ -12,18 +12,19 @@ const (
 
 // valid values for NotificationConfig.Type.
 const (
-	TypeEmail          = "email"
-	TypeSlack          = "slack"
-	TypeSplunk         = "splunk"
-	TypeAmazonSqs      = "amazon_sqs"
-	TypeJira           = "jira"
-	TypeMicrosoftTeams = "microsoft_teams"
-	TypeWebhook        = "webhook"
-	TypeAwsSecurityHub = "aws_security_hub"
-	TypeGoogleCscc     = "google_cscc"
-	TypeServiceNow     = "service_now"
-	TypePagerDuty      = "pager_duty"
-	TypeDemisto        = "demisto"
+	TypeEmail                = "email"
+	TypeSlack                = "slack"
+	TypeSplunk               = "splunk"
+	TypeAmazonSqs            = "amazon_sqs"
+	TypeJira                 = "jira"
+	TypeMicrosoftTeams       = "microsoft_teams"
+	TypeWebhook              = "webhook"
+	TypeAwsSecurityHub       = "aws_security_hub"
+	TypeGoogleCscc           = "google_cscc"
+	TypeServiceNow           = "service_now"
+	TypePagerDuty            = "pager_duty"
+	TypeDemisto              = "demisto"
+	TypeAzureServiceBusQueue = "azure_service_bus_queue"
 )
 
 const (


### PR DESCRIPTION
## Description

Added Azure Service Bus Queue integration type to alert/rule/const.go

## Motivation and Context

Azure Service Bus Queue is not supported in prisma's terraform provider as the allowed types are [reference this sdk](https://github.com/PaloAltoNetworks/terraform-provider-prismacloud/blob/master/prismacloud/resource_alert_rule.go#L264).  Added the appropriate type of allowed values as specified by api documentation.

## How Has This Been Tested?

Verified local unit tests pass `go test -v ./...` and minimal evaluation using out instance hosted on api3.prismacloud.io.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [n/a] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [n/a] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
