### PR TITLE
Added omitempty tag to r_rule_schedule

### DIFF
--- a/alert/rule/structs.go
+++ b/alert/rule/structs.go
@@ -52,7 +52,7 @@ type NotificationConfig struct {
 	TemplateId         string   `json:"templateId,omitempty"`
 	Timezone           Timezone `json:"timezone"`
 	DayOfMonth         int      `json:"dayOfMonth"`
-	RruleSchedule      string   `json:"rruleSchedule"`
+	RruleSchedule      string   `json:"rruleSchedule,omitempty"`
 	FrequencyFromRrule string   `json:"frequencyFromRRule"`
 	HourOfDay          int      `json:"hourOfDay"`
 	DaysOfWeek         []Day    `json:"daysOfWeek"`


### PR DESCRIPTION
Added omitempty tag to r_rule_schedule to fix alert rule issue - Cannot create an instant emailing alerting rule