### PR TITLE
Include Jira as a Notification Config type

### DIFF
--- a/alert/rule/const.go
+++ b/alert/rule/const.go
@@ -26,6 +26,7 @@ const (
 	TypeAzureServiceBusQueue = "azure_service_bus_queue"
 	TypeSnowFlake            = "snowflake"
 	TypeAwsS3                = "aws_s3"
+	TypeJira		 = "jira"
 )
 
 const (


### PR DESCRIPTION
Jira is missing as a config type for alert rules.
