### PR TITLE
Adding support for AccessKeyMaxValidity and AlarmEnabled in enterprise settings schema

### DIFF
--- a/settings/enterprise/const.go
+++ b/settings/enterprise/const.go
@@ -1,12 +1,5 @@
 package enterprise
 
-// Valid values for AnomalyTrainingModelThreshold and AnomalyAlertDisposition.
-const (
-	Low    = "low"
-	Medium = "medium"
-	High   = "high"
-)
-
 const (
 	singular = "enterprise settings"
 )

--- a/settings/enterprise/structs.go
+++ b/settings/enterprise/structs.go
@@ -2,10 +2,10 @@ package enterprise
 
 type Config struct {
 	SessionTimeout                int             `json:"sessionTimeout,omitempty"`
-	AnomalyTrainingModelThreshold string          `json:"anomalyTrainingModelThreshold,omitempty"`
-	AnomalyAlertDisposition       string          `json:"anomalyAlertDisposition,omitempty"`
 	UserAttributionInNotification bool            `json:"userAttributionInNotification"`
 	RequireAlertDismissalNote     bool            `json:"requireAlertDismissalNote"`
 	DefaultPoliciesEnabled        map[string]bool `json:"defaultPoliciesEnabled"`
 	ApplyDefaultPoliciesEnabled   bool            `json:"applyDefaultPoliciesEnabled"`
+	AccessKeyMaxValidity          int             `json:"accessKeyMaxValidity"`
+	AlarmEnabled                  bool            `json:"alarmEnabled"`
 }


### PR DESCRIPTION
Adding support for AccessKeyMaxValidity and AlarmEnabled in enterprise settings schema