### PR TITLE
add build policy validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/paloaltonetworks/prisma-cloud-go
 
 go 1.13
+
+require gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/policy/const.go
+++ b/policy/const.go
@@ -33,3 +33,4 @@ const (
 )
 
 var Suffix = []string{"policy"}
+var BridgecrewSuffix = []string{"bridgecrew/api/v1/policies"}


### PR DESCRIPTION
## Description

Adds support for validation of code security build policies.

## Motivation and Context

This update was to ensure that code security build policies can be validated before creation in the terraform provider. 

## How Has This Been Tested?

This was tested by creating code security build policies using the terraform provider. The following tests were conducted to ensure existing functionality is not affected:

- creation of a run-only policy
- creation of a valid build-only policy
- creation of an invalid build-only policy
- creation of a run + build policy

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
