### PR TITLE
chore: Add Access Key API Methods

### DIFF
--- a/access-key/const.go
+++ b/access-key/const.go
@@ -1,0 +1,8 @@
+package accesskey
+
+const (
+	singular = "access-key"
+	plural   = "accesskeys"
+)
+
+var Suffix = []string{"access_keys"}

--- a/access-key/const.go
+++ b/access-key/const.go
@@ -1,8 +1,8 @@
 package accesskey
 
 const (
-	singular = "access-key"
-	plural   = "accesskeys"
+	singular = "access key"
+	plural   = "access keys"
 )
 
 var Suffix = []string{"access_keys"}

--- a/access-key/funcs.go
+++ b/access-key/funcs.go
@@ -1,0 +1,67 @@
+package accesskey
+
+import (
+	"strconv"
+
+	pc "github.com/paloaltonetworks/prisma-cloud-go"
+)
+
+// List returns a list of access keys
+func List(c pc.PrismaCloudClient) ([]AccessKey, error) {
+	c.Log(pc.LogAction, "(get) list of %s", plural)
+
+	var ans []AccessKey
+	path := Suffix[:]
+
+	_, err := c.Communicate("GET", path, nil, nil, &ans)
+	return ans, err
+}
+
+// Get returns an access key by ID
+func Get(c pc.PrismaCloudClient, id string) (AccessKey, error) {
+	c.Log(pc.LogAction, "(get) %s", singular)
+
+	path := make([]string, 0, len(Suffix)+1)
+	path = append(path, Suffix...)
+	path = append(path, id)
+
+	var ans AccessKey
+	_, err := c.Communicate("GET", path, nil, nil, &ans)
+	return ans, err
+}
+
+// Create adds a new access key
+func Create(c pc.PrismaCloudClient, accKey AccessKey) (AccessKey, error) {
+	c.Log(pc.LogAction, "(create) %s", singular)
+
+	path := Suffix[:]
+	var ans AccessKey
+	_, err := c.Communicate("POST", path, nil, accKey, &ans)
+	return ans, err
+}
+
+// Update changes a status of an existing access key
+func Update(c pc.PrismaCloudClient, accKey AccessKey) error {
+	c.Log(pc.LogAction, "(udpate) %s", singular)
+
+	path := make([]string, 0, len(Suffix)+3)
+	path = append(path, Suffix...)
+	path = append(path, accKey.Id)
+	path = append(path, "status")
+	path = append(path, strconv.FormatBool(accKey.Status))
+
+	_, err := c.Communicate("PATCH", path, nil, nil, nil)
+	return err
+}
+
+// Delete removes an access key by ID
+func Delete(c pc.PrismaCloudClient, id string) error {
+	c.Log(pc.LogAction, "(delete) %s", singular)
+
+	path := make([]string, 0, len(Suffix)+1)
+	path = append(path, Suffix...)
+	path = append(path, id)
+
+	_, err := c.Communicate("DELETE", path, nil, nil, nil)
+	return err
+}

--- a/access-key/structs.go
+++ b/access-key/structs.go
@@ -1,0 +1,20 @@
+package accesskey
+
+type AccessKey struct {
+	CreatedBy          string `json:"createdBy,omitempty"`
+	CreatedTimestamp   int    `json:"createdTs,omitempty"`
+	ExpiresOn          int    `json:"expiresOn,omitempty"`
+	Id                 string `json:"id,omitempty,omitempty"`
+	LastUsed           int    `json:"lastUsedTime,omitempty"`
+	Name               string `json:"name,omitempty"`
+	Role               Role   `json:"role,omitempty"`
+	RoleType           string `json:"roleType,omitempty"`
+	Status             bool   `json:"status,omitempty"`
+	Username           string `json:"username,omitempty"`
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+	SecretKey          string `json:"secretKey,omitempty"`
+}
+
+type Role struct {
+	Name string `json:"name"`
+}


### PR DESCRIPTION
## Description

See this for reference: https://pan.dev/prisma-cloud/api/cspm/access-keys/

Examples:

```go

// List all keys
res, err := accesskey.List(client)

// Get a key with id 0146edc0-99ec-4418-979f-82173c5271c8
res, err := accesskey.Get(client, "0146edc0-99ec-4418-979f-82173c5271c8")

// Create a key with name TestKey1 as a service account Terraform with expiration date
accKey := accesskey.AccessKey{Name: "TestKey1", ServiceAccountName: "Terraform", ExpiresOn: 1888661848528}
res, err := accesskey.Create(client, accKey)

// Delete a key with id 4ec889a8-26c7-4c59-8846-50b663cd6a28
err := accesskey.Delete(client, "4ec889a8-26c7-4c59-8846-50b663cd6a28")

// Update a key with id 04cbf090-2299-4c5d-ab3c-edb9bea6260d status to inactive
accKey := accesskey.AccessKey{Id: "04cbf090-2299-4c5d-ab3c-edb9bea6260d", Status: false}
err := accesskey.Update(client, accKey)

```

## Motivation and Context

I want to work on a PR to add this to Terraform Provider for Prisma Cloud and this would be a requirement https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs

## How Has This Been Tested?

See above

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
